### PR TITLE
remove <--!more--> tag in elhmn s description

### DIFF
--- a/content/post/contributors/elhmn.md
+++ b/content/post/contributors/elhmn.md
@@ -4,4 +4,4 @@ date: 2021-01-29T20:33:40+01:00
 authors: ["Elhmn"]
 ---
 
-Hi! I’m **Boris Mbarga**. Self-taught and passionate software engineer. I’m mainly interested in computer graphics, artificial intelligence web/software/mobile development, Math, Physics and visual art. <!--more-->I enjoy finding elegant solutions to relatively complex problems you might encounter. But what I like the most is to share and learn from others.
+Hi! I’m **Boris Mbarga**. Self-taught and passionate software engineer. I’m mainly interested in computer graphics, artificial intelligence web/software/mobile development, Math, Physics and visual art. I enjoy finding elegant solutions to relatively complex problems you might encounter. But what I like the most is to share and learn from others.


### PR DESCRIPTION
#### This PR removes the `<--!more-->` tag in the elhmn's contributor file

The `<--!more-->` tag was added in the elhmn's file to shorten the length of the preview on the home page.
But the tag also caused the template to display unnecessary `html` tags.

### BEFORE:
<img width="373" alt="Screenshot 2021-02-07 at 09 36 26" src="https://user-images.githubusercontent.com/5704817/107141293-106b2e00-6928-11eb-8100-0b2698e35007.png">

### AFTER:
<img width="378" alt="Screenshot 2021-02-07 at 09 36 33" src="https://user-images.githubusercontent.com/5704817/107141298-13feb500-6928-11eb-8aa4-efa468bb4caf.png">
